### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ a.nodes() # Returns a list of dicts
 from routedbits import RoutedBits
 
 a.RoutedBits()
-a.nodes(name="dal1")
+a.node(name="dal1")
 
 print(a)
 


### PR DESCRIPTION
Fix typo in README.md on looking up a singular node.

The `nodes()` method (plural) returns all nodes whereas the `node(name="<name>")` is the function for returning a specific router.
